### PR TITLE
Fix import JSON modal from dashboard tile

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -70,7 +70,8 @@ export const App = () => {
 							<Route path='/' element={
 								<Dashboard
 									displayWizard={displayWizard}
-									setDisplayWizard={setDisplayWizard} />
+									setDisplayWizard={setDisplayWizard}
+									setDisplayedModal={setDisplayedModal} />
 							} />
 							<Route path='/edit/:id' element={<Edit />} />
 							<Route path='/help/:id' element={<Help />} />


### PR DESCRIPTION
This Pull Request resolves #160 

**What is the problem?**

The *Import JSON* tile/button from the dashboard goes to a 404 error (without changing the url) this "crashes" the app and the only workaround is to refresh the page. Also on the console we can see the error "setDisplayedModal is not a function" on the ClickableTile component.

![image](https://user-images.githubusercontent.com/36615882/195954146-6061b0d5-b684-4d7d-ad44-b4b59c249ddf.png)

**What is the solution?**

The problem on the console indicates the *setDisplayedModal* function is either called incorrectly or not found at all, so adding the setDisplayedModal function on the Dashboard component (because is the parent of ClickableTile component) resolves this issue, making the button totally functional again and it doesn't print any errors on the console anymore 🥳 

![image](https://user-images.githubusercontent.com/36615882/195954607-791706a1-0c8c-426f-bc80-b9cc8863b1b5.png)
