### PR TITLE
Add missing export attributes for tag component (#157)

### DIFF
--- a/src/fragment-components/a-tag.tsx
+++ b/src/fragment-components/a-tag.tsx
@@ -71,6 +71,17 @@ export const ATagSettingsUI = ({ selectedComponent, setComponent }: any) => {
 			})}
 		/>
 
+		<TextInput
+			value={selectedComponent.closeLabel}
+			labelText='Close filter label'
+			onChange={(event: any) => {
+				setComponent({
+					...selectedComponent,
+					closeLabel: event.currentTarget.value
+				});
+			}}
+		/>
+
 		<Checkbox
 			labelText='Is filter'
 			id='filter'
@@ -147,13 +158,11 @@ export const componentInfo: ComponentInfo = {
 			inputs: ({ json }) => `@Input() ${nameStringToVariableString(json.codeContext?.name)}Title = "${json.title}";
 				@Input() ${nameStringToVariableString(json.codeContext?.name)}Type = "${json.kind}";`,
 			outputs: ({ json }) => `${json.filter
-				? `@Output() ${nameStringToVariableString(json.codeContext?.name)}Close = new EventEmitter();`
+				? `@Output() ${nameStringToVariableString(json.codeContext?.name)}Click = new EventEmitter();
+					@Output() ${nameStringToVariableString(json.codeContext?.name)}Close = new EventEmitter();`
 				: ''
 			}`,
 			imports: ['TagModule'],
-			// NOTE: Angular tag does not support 'disabled' yet. Filtered tag is able to take in 'disabled' as an input
-			// but it doesn't do anything.
-			// Issue is being tracked here: https://github.com/IBM/carbon-components-angular/issues/2061
 			code: ({ json }) => {
 				const defaultProps = `
 					[type]="${nameStringToVariableString(json.codeContext?.name)}Type"
@@ -163,9 +172,11 @@ export const componentInfo: ComponentInfo = {
 				if (json.filter) {
 					return `<ibm-tag-filter
 						${defaultProps}
+						(click)='${nameStringToVariableString(json.codeContext?.name)}Click.emit()'
 						(close)='${nameStringToVariableString(json.codeContext?.name)}Close.emit()'
 						${angularClassNamesFromComponentObj(json)}
-						[disabled]='${json.disabled}'>
+						[disabled]='${json.disabled}'
+						${json.closeLabel ? `closeButtonLabel='${json.closeLabel}'` : ''}>
 							${json.title}
 					</ibm-tag-filter>
 					`;
@@ -184,6 +195,7 @@ export const componentInfo: ComponentInfo = {
 				return `<Tag
 					${json.kind && ` type="${json.kind}"`}
 					${`size='${json.size ? json.size : 'md'}'`}
+					${json.closeLabel && `title="${json.closeLabel}"`}
 					disabled={${json.disabled}}
 					filter={${json.filter}}
 					${reactClassNamesFromComponentObj(json)}>

--- a/src/ui-fragment/src/components/ui-tag.tsx
+++ b/src/ui-fragment/src/components/ui-tag.tsx
@@ -8,6 +8,7 @@ export interface TagState {
 	title: string;
 	id: string | number;
 	size?: string;
+	closeLabel?: string;
 	filter?: boolean;
 	disabled?: boolean;
 	cssClasses?: CssClasses[];
@@ -31,6 +32,7 @@ export const UITag = ({ state }: {
 	size={state.size}
 	disabled={state.disabled}
 	filter={state.filter}
+	title={state.closeLabel}
 	className={state.cssClasses?.map((cc: any) => cc.id).join(' ')}>
 		{state.title}
 	</Tag>;


### PR DESCRIPTION
Hello there,

These changes should bring the code export for the `Tag` component up to date with v10 of Carbon Design System.

---

The React version could also export a stub for `onClose`, but I have a question about what I noticed was already in place.

https://github.com/IBM/carbon-ui-builder/blob/5af3177ad750411c4b87d73744d489c23554da73/src/routes/edit/share-options/exports/frameworks/react-fragment.ts#L195-L197

Using the `Checkbox` component as an example:

https://github.com/IBM/carbon-ui-builder/blob/5af3177ad750411c4b87d73744d489c23554da73/src/fragment-components/a-checkbox.tsx#L104-L111

Something doesn't look quite right about how `checked` is binding in the JSX.

Here, I believe `state` would end up looking like a whole bunch of auto-generated component names to booleans (e.g. `{ "checkbox-123": true }`).

To allow for the possibility a component might have multiple handlers to export, `handleInputChange` could change slightly such that it also includes another name (e.g. `checked`) to stash the actual value (e.g. `true`), and then for the `setState` to ensure it incorporates this extra nested level properly.

If somebody can clear up my observation above, I can also amend my changes to add the `onClose` for the React code export.