### PR TITLE
Add cross-env for cross platform project start

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/webpack-env": "1.17.0",
     "@typescript-eslint/eslint-plugin": "5.25.0",
     "@typescript-eslint/parser": "5.25.0",
+    "cross-env": "7.0.3",
     "cypress": "9.6.1",
     "eslint": "8.15.0",
     "eslint-plugin-react": "7.30.0",
@@ -60,7 +61,7 @@
     "ts-jest": "28.0.2"
   },
   "scripts": {
-    "start": "GENERATE_SOURCEMAP=false react-scripts start",
+    "start": "cross-env GENERATE_SOURCEMAP=false react-scripts start",
     "build": "react-scripts build",
     "lint": "eslint --ext .js,.ts,.jsx,.tsx 'src/**'",
     "lint:fix": "eslint --ext .js,.ts,.jsx,.tsx 'src/**' --fix",


### PR DESCRIPTION
Hello there,

Following some discussion in #157, these changes simply introduce the `cross-env` package to make `npm start` execute seamlessly across platforms when any npm scripts require setting of environment variables.

Currently, for anybody trying to run `npm start` in Command Prompt in Windows, they'll likely hit a message like:

```
'GENERATE_SOURCEMAP' is not recognized as an internal or external command,
operable program or batch file.
```

If it's not worthwhile enough (i.e. telling such users to use a different shell, or work around it another way), I don't mind if these changes are just closed off.

---

Separately, while on the topic of Windows environments, the ESLint configuration will go bonkers in reporting warnings under the `linebreak-style` rule for every single file in the repository (assuming Git has been installed to check in as LF and check out as CRLF, which I believe is the default setting).

```
src\utils\fragment-tools.ts
  Line 1:27:     Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
  Line 2:39:     Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
  Line 3:34:     Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
  ...
```

Currently, the relevant configuration is:
https://github.com/IBM/carbon-ui-builder/blob/5af3177ad750411c4b87d73744d489c23554da73/.eslintrc.js#L30-L33

There's some relevant information from the ESLint website about this problem specifically.

https://eslint.org/docs/latest/rules/linebreak-style#using-this-rule-with-version-control-systems

One suggestion would be to replace `'unix'` with `process.platform === 'win32' ? 'windows' : 'unix'` (can confirm this works, at least for me).

Again, the suggestion can be ignored if the developer experience of non-Unix users isn't a priority.