### PR TITLE
Adds PR template feature

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,7 @@
 
 For Work In Progress Pull Requests, please use the [Draft pull request feature](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
 
-For pull requests that relate or close an issue, please include them
-below. [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+For pull requests that relate or close an issue, please include them below. [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
 
 -->
 
@@ -46,7 +45,7 @@ ex. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
 Describe the `how` of the PR.
 
 Provide a summary of:
- - coxtext behind changes made
+ - context behind changes made
  - what reviewers should pay extra attention to
  - what, if anything, was refactored
  - who, if anyone, collaborated on this PR

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,86 @@
+## Related Tickets & Documents
+
+<!--
+
+For Work In Progress Pull Requests, please use the [Draft pull request feature](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
+
+For pull requests that relate or close an issue, please include them
+below. [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+
+-->
+
+- Related Issue #
+- Closes #
+
+
+## What type of PR is this? (check all that apply)
+
+<!--
+
+Syntax example:
+ - [x] Feature
+
+ -->
+
+
+- [ ] Feature
+- [ ] Bug Fix
+- [ ] Refactor
+- [ ] Documentation Update
+
+
+## Scope
+
+<!--
+
+Describe the `what` and `why` of the PR.
+
+ex. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
+
+-->
+
+## Implementation
+
+<!--
+
+Describe the `how` of the PR.
+
+Provide a summary of:
+ - coxtext behind changes made
+ - what reviewers should pay extra attention to
+ - what, if anything, was refactored
+ - who, if anyone, collaborated on this PR
+
+-->
+
+## Screenshots/Recordings/Diagrams:
+
+<!---
+
+Include a relevant form of visual documentation
+
+-->
+
+## How to test
+
+<!--
+
+Instruct how reviewers can test changes
+
+-->
+
+## [optional] To-do before merge
+
+<!---
+
+Include any notes about things that need to happen before this PR is merged
+
+-->
+
+## [optional] To-do after merge
+
+<!---
+
+Include any notes about things that need to happen after this PR is merged
+
+-->


### PR DESCRIPTION
## Related Tickets
Closes #173 


## What type of PR is this? (check all that apply)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update



## Scope
Adds PR template feature

## Implementation
Created a .md file because at this time, .md is the required file type for a pr template in Github.

Again happy to switch around, add or remove sections and change any wording to better suit the repo! ☺️


## Screenshot
![screenshot of PR template](https://user-images.githubusercontent.com/19538219/197463324-fbad666c-e02d-486b-956b-a3dba94dc6ea.png)

## How to test
To see the template in action I picked a [random fork to merge into my main](https://github.com/sadiejay/carbon-ui-builder/compare/main...MoizMasud:carbon-components-builder:code-snippet). Then press the `create pull request` button. As long as my fork is the base repo, you can change the head repo to any other fork with applicable changes to see the PR template! 😊

