### PR TITLE
ci: Add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Check build
+
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout to branch
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Set up node to use v16 & cache node modules
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "npm"
+          cache-dependency-path: "package-lock.json"
+
+      # Install dependencies
+      - name: Install dependencies
+        run: npm install
+
+      # Build the react app, linting errors will be included in build
+      - name: Build site
+        run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,6 @@ on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ env:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  deploy:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
- In netlfiy deploy preview, we no longer do lint checks, this will allow us to view the deploy preview without build failing. It will allow us to review the overall functionality. This can speed up reviews since we don't have to wait for the users to fix the linting errors before seeing the deploy preview.
- The build job will now check to see if the react application can build, in this process it will also run the linter since the rules are set to throw an `error` in .eslintrc.js
