### PR TITLE
fix: Reference type instead of object key in additional code export

### DIFF
--- a/src/routes/edit/share-options/exports/frameworks/react-fragment.ts
+++ b/src/routes/edit/share-options/exports/frameworks/react-fragment.ts
@@ -80,8 +80,8 @@ export const getAdditionalCode = (componentObj: any, fragments: any[]) => {
 	}
 	let collectedCode = {};
 
-	for (const [key, component] of Object.entries(allComponents)) {
-		if (componentObj.type === key && !component.componentInfo.codeExport.react.isNotDirectExport) {
+	for (const component of Object.values(allComponents)) {
+		if (componentObj.type === component.componentInfo.type && !component.componentInfo.codeExport.react.isNotDirectExport) {
 			if (component.componentInfo.codeExport.react.additionalCode) {
 				collectedCode = { ...collectedCode, ...component.componentInfo.codeExport.react.additionalCode(componentObj) };
 			}


### PR DESCRIPTION
Closes # 136


## What type of PR is this? (check all that apply)
- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update


## Scope
PR will enable additionalCode to be returned in selectable tiles & selectable tiles group components

## Implementation
A previous PR changed (#69, improved type-mapping) how we accessed the components from using the key (in index) to using the type defined within the component. This change uses the type defined in the component to ensure that `additionalCode` is passed in exports. 

## How to test
In deploy preview, Add selectable tile group or selectable tile & export (react) and you will be able to see the additional code.

