### PR TITLE
Expand React export to support Actions

### DIFF
--- a/src/fragment-components/a-button.tsx
+++ b/src/fragment-components/a-button.tsx
@@ -9,6 +9,7 @@ import { AComponent, ComponentInfo } from './a-component';
 
 import image from './../assets/component-icons/button.svg';
 import { angularClassNamesFromComponentObj, nameStringToVariableString, reactClassNamesFromComponentObj } from '../utils/fragment-tools';
+import { getReactCodeForActions } from './../routes/edit/share-options/exports/frameworks/react/utils';
 
 export const AButtonSettingsUI = ({ selectedComponent, setComponent }: any) => {
 	const kindItems = [
@@ -138,11 +139,13 @@ export const componentInfo: ComponentInfo = {
 		},
 		react: {
 			imports: ['Button'],
-			code: ({ json }) => {
+			code: ({ json, signals, slots }) => {
 				return `<Button
-					${json.kind && `kind="${json.kind}"`}
-					${json.size && `size="${json.size}"`}
-					${reactClassNamesFromComponentObj(json)}>${json.text}</Button>`;
+					${json.kind ? `kind="${json.kind}"` : ``}
+					${json.size ? `size="${json.size}"` : ``}
+					${reactClassNamesFromComponentObj(json)}
+					${getReactCodeForActions(signals, slots, json.codeContext?.name)}
+					>${json.text}</Button>`;
 			}
 		}
 	}

--- a/src/fragment-components/a-button.tsx
+++ b/src/fragment-components/a-button.tsx
@@ -141,8 +141,8 @@ export const componentInfo: ComponentInfo = {
 			imports: ['Button'],
 			code: ({ json, signals, slots }) => {
 				return `<Button
-					${json.kind ? `kind="${json.kind}"` : ``}
-					${json.size ? `size="${json.size}"` : ``}
+					${json.kind ? `kind="${json.kind}"` : ''}
+					${json.size ? `size="${json.size}"` : ''}
 					${reactClassNamesFromComponentObj(json)}
 					${getReactCodeForActions(signals, slots, json.codeContext?.name)}
 					>${json.text}</Button>`;

--- a/src/fragment-components/a-button.tsx
+++ b/src/fragment-components/a-button.tsx
@@ -144,8 +144,9 @@ export const componentInfo: ComponentInfo = {
 					${json.kind ? `kind="${json.kind}"` : ''}
 					${json.size ? `size="${json.size}"` : ''}
 					${reactClassNamesFromComponentObj(json)}
-					${getReactCodeForActions(signals, slots, json.codeContext?.name)}
-					>${json.text}</Button>`;
+					${getReactCodeForActions(signals, slots, json.codeContext?.name)}>
+						${json.text}
+					</Button>`;
 			}
 		}
 	}

--- a/src/fragment-components/a-component.tsx
+++ b/src/fragment-components/a-component.tsx
@@ -56,17 +56,19 @@ export interface ComponentInfo {
 			outputs: (props: { json: any }) => string;
 			imports: string[];
 			isNotDirectExport?: boolean;
-			code: (props: {json: any; jsonToTemplate: (json: any, fragments: any[]) => string; fragments: any[]}) => string;
+			code: (props: { json: any; jsonToTemplate: (json: any, fragments: any[]) => string; fragments: any[] }) => string;
 		};
 		react: {
-			imports: ((props: {json: any}) => string[]) | string[];
-			otherImports?: (props: {json: any; fragments?: any[]}) => string;
+			imports: ((props: { json: any }) => string[]) | string[];
+			otherImports?: (props: { json: any; fragments?: any[] }) => string;
 			isNotDirectExport?: boolean;
 			code: (props: {
-				json: any; 
-				signals: any; 
-				slots: any; 
-				jsonToTemplate: (json: any, signals: any, slots: any, fragments: any[]) => string; fragments: any[]}) => string;
+				json: any;
+				signals: any;
+				slots: any;
+				jsonToTemplate: (json: any, signals: any, slots: any, fragments: any[]) => string;
+				fragments: any[];
+			}) => string;
 			additionalCode?: (componentObj: any) => any;
 		};
 	};
@@ -149,41 +151,41 @@ export const AComponent = ({
 
 	return (
 		<span
-		className={cx(className, showDragOverIndicator ? dropIndicatorStyle : '')}
-		ref={holderRef}
-		onClick={(event) => {
-			event.stopPropagation();
-			select();
-		}}
-		draggable='true' // TODO make Draggable32 the drag handle and this element as preview
-		onDragStart={(event: any) => drag(event, {
-			component: componentObj,
-			type: 'move'
-		})}
-		onDragEnter={(event: any) => {
-			if (shouldRejectDrop(event)) {
-				return true;
-			}
-			event.stopPropagation();
-			event.preventDefault();
-			setShowDragOverIndicator(true);
-		}}
-		onDragLeave={(event: any) => {
-			if (shouldRejectDrop(event)) {
-				return true;
-			}
-			event.stopPropagation();
-			event.preventDefault();
-			setShowDragOverIndicator(false);
-		}}
-		onDragOver={(event) => {
-			if (shouldRejectDrop(event)) {
-				return true;
-			}
-			event.stopPropagation();
-			event.preventDefault();
-		}}
-		onDrop={onDrop}>
+			className={cx(className, showDragOverIndicator ? dropIndicatorStyle : '')}
+			ref={holderRef}
+			onClick={(event) => {
+				event.stopPropagation();
+				select();
+			}}
+			draggable='true' // TODO make Draggable32 the drag handle and this element as preview
+			onDragStart={(event: any) => drag(event, {
+				component: componentObj,
+				type: 'move'
+			})}
+			onDragEnter={(event: any) => {
+				if (shouldRejectDrop(event)) {
+					return true;
+				}
+				event.stopPropagation();
+				event.preventDefault();
+				setShowDragOverIndicator(true);
+			}}
+			onDragLeave={(event: any) => {
+				if (shouldRejectDrop(event)) {
+					return true;
+				}
+				event.stopPropagation();
+				event.preventDefault();
+				setShowDragOverIndicator(false);
+			}}
+			onDragOver={(event) => {
+				if (shouldRejectDrop(event)) {
+					return true;
+				}
+				event.stopPropagation();
+				event.preventDefault();
+			}}
+			onDrop={onDrop}>
 			<span className={cx(headerStyle, headingCss, selected ? css`` : css`display: none`)}>
 				<span className={css`margin-right: 1rem`}>
 					{componentObj && componentObj.type ? componentObj.type : 'Header'}

--- a/src/fragment-components/a-component.tsx
+++ b/src/fragment-components/a-component.tsx
@@ -62,7 +62,11 @@ export interface ComponentInfo {
 			imports: ((props: {json: any}) => string[]) | string[];
 			otherImports?: (props: {json: any; fragments?: any[]}) => string;
 			isNotDirectExport?: boolean;
-			code: (props: {json: any; signals: any; slots: any, jsonToTemplate: (json: any, signals: any, slots: any, fragments: any[]) => string; fragments: any[]}) => string;
+			code: (props: {
+				json: any; 
+				signals: any; 
+				slots: any; 
+				jsonToTemplate: (json: any, signals: any, slots: any, fragments: any[]) => string; fragments: any[]}) => string;
 			additionalCode?: (componentObj: any) => any;
 		};
 	};

--- a/src/fragment-components/a-component.tsx
+++ b/src/fragment-components/a-component.tsx
@@ -62,7 +62,7 @@ export interface ComponentInfo {
 			imports: ((props: {json: any}) => string[]) | string[];
 			otherImports?: (props: {json: any; fragments?: any[]}) => string;
 			isNotDirectExport?: boolean;
-			code: (props: {json: any; jsonToTemplate: (json: any, fragments: any[]) => string; fragments: any[]}) => string;
+			code: (props: {json: any; signals: any; slots: any, jsonToTemplate: (json: any, signals: any, slots: any, fragments: any[]) => string; fragments: any[]}) => string;
 			additionalCode?: (componentObj: any) => any;
 		};
 	};

--- a/src/fragment-components/a-grid.tsx
+++ b/src/fragment-components/a-grid.tsx
@@ -192,11 +192,11 @@ export const componentInfo: ComponentInfo = {
 		},
 		react: {
 			imports: ['Grid', 'Column', 'Row'],
-			code: ({ json, fragments, jsonToTemplate }) => {
+			code: ({ json, signals, slots, fragments, jsonToTemplate }) => {
 				return `<Grid ${reactClassNamesFromComponentObj(json)}>
 					${json.items.map((row: any) => `<Row ${reactClassNamesFromComponentObj(row)}>
 						${row.items.map((cell: any) => `<Column ${getCellParamsStringReact(cell)} ${reactClassNamesFromComponentObj(cell)}>
-								${jsonToTemplate(cell, fragments)}
+								${jsonToTemplate(cell, signals, slots, fragments)}
 						</Column>`).join('\n')}
 					</Row>`).join('\n')}
 				</Grid>`;

--- a/src/fragment-components/a-radio-group.tsx
+++ b/src/fragment-components/a-radio-group.tsx
@@ -185,7 +185,7 @@ export const componentInfo: ComponentInfo = {
 		},
 		react: {
 			imports: ['RadioButtonGroup'],
-			code: ({ json, fragments, jsonToTemplate }) => {
+			code: ({ json, signals, slots, fragments, jsonToTemplate }) => {
 				return `<RadioButtonGroup
 					name="${json.codeContext?.name}"
 					legendText="${json.legend}"
@@ -199,7 +199,7 @@ export const componentInfo: ComponentInfo = {
 							name: "${json.codeContext?.name}"
 						}
 					})}>
-						${json.items.map((element: any) => jsonToTemplate(element, fragments)).join('\n')}
+						${json.items.map((element: any) => jsonToTemplate(element, signals, slots, fragments)).join('\n')}
 				</RadioButtonGroup>`;
 			}
 		}

--- a/src/fragment-components/accordion/a-accordion-item.tsx
+++ b/src/fragment-components/accordion/a-accordion-item.tsx
@@ -152,12 +152,12 @@ export const componentInfo: ComponentInfo = {
 		},
 		react: {
 			imports: ['AccordionItem'],
-			code: ({ json, fragments, jsonToTemplate }) => {
+			code: ({ json, signals, slots, fragments, jsonToTemplate }) => {
 				return `<AccordionItem
 					title="${json.title || ''}"
 					${json.disabled !== undefined ? `disabled={${json.disabled}}` : ''}
 					${reactClassNamesFromComponentObj(json)}>
-						${json.items.map((element: any) => jsonToTemplate(element, fragments)).join('\n')}
+						${json.items.map((element: any) => jsonToTemplate(element, signals, slots, fragments)).join('\n')}
 				</AccordionItem>`;
 			}
 		}

--- a/src/fragment-components/accordion/a-accordion.tsx
+++ b/src/fragment-components/accordion/a-accordion.tsx
@@ -107,12 +107,12 @@ export const componentInfo: ComponentInfo = {
 		},
 		react: {
 			imports: ['Accordion'],
-			code: ({ json, fragments, jsonToTemplate }) => {
+			code: ({ json, signals, slots, fragments, jsonToTemplate }) => {
 				return `<Accordion
 					${json.align !== undefined ? `align='${json.align}'` : ''}
 					${json.size !== undefined ? `size='${json.size}'` : ''}
 					${reactClassNamesFromComponentObj(json)}>
-						${json.items.map((element: any) => jsonToTemplate(element, fragments)).join('\n')}
+						${json.items.map((element: any) => jsonToTemplate(element, signals, slots, fragments)).join('\n')}
 				</Accordion>`;
 			}
 		}

--- a/src/fragment-components/tiles/a-clickable-tile.tsx
+++ b/src/fragment-components/tiles/a-clickable-tile.tsx
@@ -150,13 +150,13 @@ export const componentInfo: ComponentInfo = {
 		},
 		react: {
 			imports: ['ClickableTile'],
-			code: ({ json, fragments, jsonToTemplate }) => {
+			code: ({ json, signals, slots, fragments, jsonToTemplate }) => {
 				return `<ClickableTile
 					${json.codeContext?.href !== undefined && json.codeContext?.href !== '' ? `href='${json.codeContext?.href}'` : ''}
 					${json.light !== undefined ? `light="${json.light}"` : ''}
 					${json.disabled !== undefined ? `disabled={${json.disabled}}` : ''}
 					${reactClassNamesFromComponentObj(json)}>
-						${json.items.map((element: any) => jsonToTemplate(element, fragments)).join('\n')}
+						${json.items.map((element: any) => jsonToTemplate(element, signals, slots, fragments)).join('\n')}
 				</ClickableTile>`;
 			}
 		}

--- a/src/fragment-components/tiles/a-expandable-tile.tsx
+++ b/src/fragment-components/tiles/a-expandable-tile.tsx
@@ -187,16 +187,16 @@ export const componentInfo: ComponentInfo = {
 		},
 		react: {
 			imports: ['ExpandableTile', 'TileAboveTheFoldContent', 'TileBelowTheFoldContent'],
-			code: ({ json, jsonToTemplate, fragments }) => {
+			code: ({ json, signals, slots, jsonToTemplate, fragments }) => {
 				const { aboveFold, belowFold } = getFoldObjects(json);
 				return `<ExpandableTile
 					${json.light !== undefined && !!json.light ? `light={${json.light}}` : ''}
 					${json.expanded !== undefined && !!json.expanded ? `expanded={${json.expanded}}` : ''}
 					${reactClassNamesFromComponentObj(json)}>
 						<TileAboveTheFoldContent>
-							${aboveFold.map((element: any) => jsonToTemplate(element, fragments)).join('\n')}
+							${aboveFold.map((element: any) => jsonToTemplate(element, signals, slots, fragments)).join('\n')}
 						</TileAboveTheFoldContent>
-						${belowFold.map((element: any) => jsonToTemplate(element, fragments)).join('\n')}
+						${belowFold.map((element: any) => jsonToTemplate(element, signals, slots, fragments)).join('\n')}
 				</ExpandableTile>`;
 			}
 		}

--- a/src/fragment-components/tiles/a-radio-tile-group.tsx
+++ b/src/fragment-components/tiles/a-radio-tile-group.tsx
@@ -210,7 +210,7 @@ export const componentInfo: ComponentInfo = {
 		},
 		react: {
 			imports: ['TileGroup'],
-			code: ({ json, jsonToTemplate, fragments }) => {
+			code: ({ json, signals, slots, jsonToTemplate, fragments }) => {
 				return `<TileGroup
 					${json.legend !== undefined && json.legend !== '' ? `legend="${json.legend}"` : ''}
 					name="${json.codeContext?.name}"
@@ -222,7 +222,7 @@ export const componentInfo: ComponentInfo = {
 							value: radio
 						}
 					})}>
-						${json.items.map((element: any) => jsonToTemplate(element, fragments)).join('\n')}
+						${json.items.map((element: any) => jsonToTemplate(element, signals, slots, fragments)).join('\n')}
 				</TileGroup>`;
 			}
 		}

--- a/src/fragment-components/tiles/a-radio-tile.tsx
+++ b/src/fragment-components/tiles/a-radio-tile.tsx
@@ -218,7 +218,7 @@ export const componentInfo: ComponentInfo = {
 		},
 		react: {
 			imports: ['RadioTile'],
-			code: ({ json, jsonToTemplate, fragments }) => {
+			code: ({ json, signals, slots, jsonToTemplate, fragments }) => {
 				return `<RadioTile
 					${
 						(json.codeContext?.formItemName !== undefined && json.codeContext?.formItemName !== '')
@@ -229,7 +229,7 @@ export const componentInfo: ComponentInfo = {
 					${json.defaultChecked ? `checked={${json.defaultChecked}}` : ''}
 					${json.disabled !== undefined && !!json.disabled ? `disabled={${json.disabled}}` : ''}
 					${reactClassNamesFromComponentObj(json)}>
-						${json.items.map((element: any) => jsonToTemplate(element, fragments)).join('\n')}
+						${json.items.map((element: any) => jsonToTemplate(element, signals, slots, fragments)).join('\n')}
 				</RadioTile>`;
 			}
 		}

--- a/src/fragment-components/tiles/a-selectable-tile-group.tsx
+++ b/src/fragment-components/tiles/a-selectable-tile-group.tsx
@@ -185,12 +185,12 @@ export const componentInfo: ComponentInfo = {
 		},
 		react: {
 			imports: [],
-			code: ({ json, jsonToTemplate, fragments }) => {
+			code: ({ json, signals, slots, jsonToTemplate, fragments }) => {
 				return `<div
 					role="group"
 					aria-label="Selectable tiles"
 					${reactClassNamesFromComponentObj(json)}>
-						${json.items.map((element: any) => jsonToTemplate(element, fragments)).join('\n')}
+						${json.items.map((element: any) => jsonToTemplate(element, signals, slots, fragments)).join('\n')}
 				</div>`;
 			}
 		}

--- a/src/fragment-components/tiles/a-selectable-tile.tsx
+++ b/src/fragment-components/tiles/a-selectable-tile.tsx
@@ -236,7 +236,7 @@ export const componentInfo: ComponentInfo = {
 		},
 		react: {
 			imports: ['SelectableTile'],
-			code: ({ json, jsonToTemplate, fragments }) => {
+			code: ({ json, signals, slots, jsonToTemplate, fragments }) => {
 				const stateFunction = json.standalone ?
 					`() => {
 						handleInputChange({
@@ -265,7 +265,7 @@ export const componentInfo: ComponentInfo = {
 					${json.disabled !== undefined && !!json.disabled ? `disabled={${json.disabled}}` : ''}
 					${reactClassNamesFromComponentObj(json)}
 					onClick={${stateFunction}}>
-						${json.items.map((element: any) => jsonToTemplate(element, fragments)).join('\n')}
+						${json.items.map((element: any) => jsonToTemplate(element, signals, slots, fragments)).join('\n')}
 				</SelectableTile>`;
 			},
 			additionalCode: (json) => {

--- a/src/fragment-components/tiles/a-tile-fold.tsx
+++ b/src/fragment-components/tiles/a-tile-fold.tsx
@@ -69,7 +69,7 @@ export const componentInfo: ComponentInfo = {
 		},
 		react: {
 			imports: [],
-			code: ({ json, signals, slots,  jsonToTemplate, fragments }) => {
+			code: ({ json, signals, slots, jsonToTemplate, fragments }) => {
 				return `<TileBelowTheFoldContent
 					${reactClassNamesFromComponentObj(json)}>
 						${json.items.map((element: any) => jsonToTemplate(element, signals, slots, fragments)).join('\n')}

--- a/src/fragment-components/tiles/a-tile-fold.tsx
+++ b/src/fragment-components/tiles/a-tile-fold.tsx
@@ -69,10 +69,10 @@ export const componentInfo: ComponentInfo = {
 		},
 		react: {
 			imports: [],
-			code: ({ json, jsonToTemplate, fragments }) => {
+			code: ({ json, signals, slots,  jsonToTemplate, fragments }) => {
 				return `<TileBelowTheFoldContent
 					${reactClassNamesFromComponentObj(json)}>
-						${json.items.map((element: any) => jsonToTemplate(element, fragments)).join('\n')}
+						${json.items.map((element: any) => jsonToTemplate(element, signals, slots, fragments)).join('\n')}
 					</TileBelowTheFoldContent>`;
 			}
 		}

--- a/src/fragment-components/tiles/a-tile.tsx
+++ b/src/fragment-components/tiles/a-tile.tsx
@@ -109,11 +109,11 @@ export const componentInfo: ComponentInfo = {
 		},
 		react: {
 			imports: ['Tile'],
-			code: ({ json, jsonToTemplate, fragments }) => {
+			code: ({ json, signals, slots, jsonToTemplate, fragments }) => {
 				return `<Tile
 					${json.light !== undefined ? `light="${json.light}"` : ''}
 					${reactClassNamesFromComponentObj(json)}>
-						${json.items.map((element: any) => jsonToTemplate(element, fragments)).join('\n')}
+						${json.items.map((element: any) => jsonToTemplate(element, signals, slots, fragments)).join('\n')}
 				</Tile>`;
 			}
 		}

--- a/src/routes/edit/share-options/exports/frameworks/react/fragment-v10.ts
+++ b/src/routes/edit/share-options/exports/frameworks/react/fragment-v10.ts
@@ -2,14 +2,15 @@ import { useContext } from 'react';
 import { GlobalStateContext } from '../../../../../../context';
 import { getAllFragmentStyleClasses } from '../../../../../../ui-fragment/src/utils';
 import { classNameFromFragment, hasFragmentStyleClasses, tagNameFromFragment } from '../../../../../../utils/fragment-tools';
-import { action, format, signalReactEvent } from '../utils';
+import { action, format } from '../utils';
 import {
 	formatOptions,
 	formatOptionsCss,
 	getAdditionalCodeAsString,
 	jsonToCarbonImports,
 	jsonToTemplate,
-	otherImportsFromComponentObj
+	otherImportsFromComponentObj,
+	signalReactEvent
 } from './utils';
 
 const generateTemplate = (json: any, fragments: any[]) => {
@@ -33,12 +34,12 @@ const generateTemplate = (json: any, fragments: any[]) => {
 				property: action.slot,
 				value: JSON.parse(action.slot_param)
 			}];
-			
+
 			if (!slots[action.destination]) {
 				slots[action.destination] = new Set<string>();
 			}
 			slots[action.destination].add(action.slot);
-		})
+		});
 	}
 	return {
 		imports: `import { ${carbonImportsString} } from 'carbon-components-react';

--- a/src/routes/edit/share-options/exports/frameworks/react/utils.ts
+++ b/src/routes/edit/share-options/exports/frameworks/react/utils.ts
@@ -117,7 +117,7 @@ export const getReactCodeForActions = (signals: any, slots: any, codeContextName
 		}
 		if (slots[codeContextName]) {
 			slots[codeContextName].forEach((property: string) => {
-				codeForActions += `${property}={state["${codeContextName}"]}`;
+				codeForActions += `${property}={state["${codeContextName}"]?.${property}}`;
 			})
 		}
 	}

--- a/src/routes/edit/share-options/exports/frameworks/react/utils.ts
+++ b/src/routes/edit/share-options/exports/frameworks/react/utils.ts
@@ -5,6 +5,7 @@ import { sortedUniq } from 'lodash';
 
 import { allComponents } from '../../../../../../fragment-components';
 import { addIfNotExist } from '../../../../../../ui-fragment/src/utils';
+import { signalType } from '../utils';
 
 export const formatOptions: Options = {
 	plugins: [parserBabel],
@@ -16,6 +17,12 @@ export const formatOptionsCss: Options = {
 	parser: 'css',
 	plugins: [parserCss]
 };
+
+export const signalReactEvent: Record<signalType, string> = {
+	click: 'onClick',
+	hover: 'onHover',
+	focus: 'onFocus'
+}
 
 export const getAdditionalCode = (componentObj: any, fragments: any[]) => {
 	if (typeof componentObj === 'string' || !componentObj) {
@@ -112,13 +119,13 @@ export const getReactCodeForActions = (signals: any, slots: any, codeContextName
 					handlePropertiesChange({
 						targets: ${JSON.stringify(signals[codeContextName][eventName])}
 					});
-				}}`
-			})
+				}}`;
+			});
 		}
 		if (slots[codeContextName]) {
 			slots[codeContextName].forEach((property: string) => {
 				codeForActions += `${property}={state["${codeContextName}"]?.${property}}`;
-			})
+			});
 		}
 	}
 	return codeForActions;

--- a/src/routes/edit/share-options/exports/frameworks/react/utils.ts
+++ b/src/routes/edit/share-options/exports/frameworks/react/utils.ts
@@ -22,7 +22,7 @@ export const signalReactEvent: Record<signalType, string> = {
 	click: 'onClick',
 	hover: 'onHover',
 	focus: 'onFocus'
-}
+};
 
 export const getAdditionalCode = (componentObj: any, fragments: any[]) => {
 	if (typeof componentObj === 'string' || !componentObj) {

--- a/src/routes/edit/share-options/exports/frameworks/utils.ts
+++ b/src/routes/edit/share-options/exports/frameworks/utils.ts
@@ -9,18 +9,12 @@ export const format = (source: string, options?: Options | undefined) => {
 	}
 };
 
-export type signalType = "click" | "hover" | "focus";
+export type signalType = 'click' | 'hover' | 'focus';
 
 export interface action {
-    source: string;
-    signal: signalType;
-    destination: string;
-    slot: string;
-    slot_param: string;
-}
-
-export const signalReactEvent: Record<signalType, string> = {
-	click: "onClick",
-	hover: "onHover",
-	focus: "onFocus"
-}
+	source: string;
+	signal: signalType;
+	destination: string;
+	slot: string;
+	slot_param: string;
+};

--- a/src/routes/edit/share-options/exports/frameworks/utils.ts
+++ b/src/routes/edit/share-options/exports/frameworks/utils.ts
@@ -8,3 +8,19 @@ export const format = (source: string, options?: Options | undefined) => {
 		return source;
 	}
 };
+
+export type signalType = "click" | "hover" | "focus";
+
+export interface action {
+    source: string;
+    signal: signalType;
+    destination: string;
+    slot: string;
+    slot_param: string;
+}
+
+export const signalReactEvent: Record<signalType, string> = {
+	click: "onClick",
+	hover: "onHover",
+	focus: "onFocus"
+}

--- a/src/routes/edit/share-options/exports/frameworks/utils.ts
+++ b/src/routes/edit/share-options/exports/frameworks/utils.ts
@@ -17,4 +17,4 @@ export interface action {
 	destination: string;
 	slot: string;
 	slot_param: string;
-};
+}


### PR DESCRIPTION
## Related Tickets & Documents

<!--

For Work In Progress Pull Requests, please use the [Draft pull request feature](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

For pull requests that relate or close an issue, please include them below. [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

-->

- Related Issue #209 


## What type of PR is this? (check all that apply)

<!--

Syntax example:
 - [x] Feature

 -->


- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update


## Implementation

<!--

Describe the `how` of the PR.

Provide a summary of:
 - context behind changes made
 - what reviewers should pay extra attention to
 - what, if anything, was refactored
 - who, if anyone, collaborated on this PR

-->

- Added some util const so nothing is hardcoded and new actions can be supported easily
- The exported code now has an event handler function that works with any properties in any element
- A `signals` and a `slots` object are passed into `jsonToTemplate` instead of the original `actions` array for performance's sake.

## How to test
1. Open an existing fragment 
2. Export the JSON
3. Add an `actions` array under `data`
4. Rename the fragment 
5. Create a new fragment by importing the new JSON
6. Export React code and test in codesandbox

<!--

Instruct how reviewers can test changes

-->
