### PR TITLE
remember the new fragment tile selection

### DIFF
--- a/src/context/global-state-context.tsx
+++ b/src/context/global-state-context.tsx
@@ -8,6 +8,7 @@ import assign from 'lodash/assign';
 import { getFragmentHelpers } from './fragments-context-helper';
 import { getFragmentJsonExport as getFragmentJsonExport_, getFragmentsFromLocalStorage } from '../utils/fragment-tools';
 import { expandJsonToState } from '../ui-fragment/src/utils';
+import { CreateOptions } from '../routes/dashboard/fragment-wizard/create-fragment-modal';
 
 const GlobalStateContext: React.Context<any> = createContext(null);
 GlobalStateContext.displayName = 'GlobalStateContext';
@@ -40,7 +41,8 @@ const GlobalStateContextProvider = ({ children }: any) => {
 	const [fragments, _setFragments] = useState<any[]>(getFragmentsFromLocalStorage());
 	const [actionHistory, setActionHistory] = useState([] as any[]);
 	const [actionHistoryIndex, setActionHistoryIndex] = useState(-1);
-
+	const [fragmentSelectionCount, _setFragmentSelectionCount] = useState(JSON.parse(localStorage.getItem('fragmentSelectionCount') as string
+	|| '{}'));
 	const [styleClasses, _setStyleClasses] = useState(JSON.parse(localStorage.getItem('globalStyleClasses') as string || '[]') as any[]);
 	const [settings, _setSettings] = useState(JSON.parse(localStorage.getItem('globalSettings') as string || '{}') as any);
 
@@ -161,6 +163,17 @@ const GlobalStateContextProvider = ({ children }: any) => {
 		return expandJsonToState(getFragmentJsonExport(fragment));
 	};
 
+	const setFragmentSelectionCount = (fragmentid: any) => {
+		const fragmentoption = CreateOptions[fragmentid];
+		const newfragmentSelectionCount = fragmentSelectionCount;
+		if (fragmentSelectionCount[fragmentoption] === undefined) {
+			newfragmentSelectionCount[fragmentoption] = 0;
+		}
+		newfragmentSelectionCount[fragmentoption]++;
+		localStorage.setItem('fragmentSelectionCount', JSON.stringify(newfragmentSelectionCount));
+		_setFragmentSelectionCount(newfragmentSelectionCount);
+	};
+
 	useEffect(() => {
 		const localFragments = JSON.parse(localStorage.getItem('localFragments') as string || '[]');
 		// clean up the hidden fragments (those marked for deletion but failed to be deleted)
@@ -202,7 +215,11 @@ const GlobalStateContextProvider = ({ children }: any) => {
 
 			// GITHUB TOKENS
 			githubToken,
-			setGithubToken
+			setGithubToken,
+
+			// TILE SELECTION
+			fragmentSelectionCount,
+			setFragmentSelectionCount
 		}}>
 			{children}
 		</GlobalStateContext.Provider>

--- a/src/routes/dashboard/fragment-wizard/create-fragment-modal.tsx
+++ b/src/routes/dashboard/fragment-wizard/create-fragment-modal.tsx
@@ -8,6 +8,7 @@ import { generateNewFragment } from './generate-new-fragment';
 import { GlobalStateContext, NotificationActionType, NotificationContext } from '../../../context';
 import { componentInfo as gridComponentInfo } from '../../../fragment-components/a-grid';
 import { initializeIds } from '../../../components';
+import { getMostFrequentFragmentSelection } from '../../../utils/fragment-tools';
 
 const createFragmentTiles = css`
 	div {
@@ -53,6 +54,11 @@ export enum CreateOptions {
 	IMPORT_JSON
 }
 
+export const isCreateOption = (value: any): value is CreateOptions => {
+	// check if create option enum has value
+	return Object.values(CreateOptions).includes(value);
+};
+
 export interface CreateFragmentModalProps {
 	shouldDisplay: boolean;
 	setShouldDisplay: (shouldDisplay: boolean) => void;
@@ -61,9 +67,9 @@ export interface CreateFragmentModalProps {
 }
 
 export const CreateFragmentModal = (props: CreateFragmentModalProps) => {
-	const [selectedCreateOption, setSelectedCreateOption] = useState<CreateOptions>(CreateOptions.EMPTY_PAGE);
+	const [selectedCreateOption, setSelectedCreateOption] = useState<CreateOptions>(getMostFrequentFragmentSelection());
 
-	const { addFragment, styleClasses, setStyleClasses } = useContext(GlobalStateContext);
+	const { addFragment, styleClasses, setStyleClasses, setFragmentSelectionCount } = useContext(GlobalStateContext);
 	const [, dispatchNotification] = useContext(NotificationContext);
 
 	const navigate: NavigateFunction = useNavigate();
@@ -98,16 +104,19 @@ export const CreateFragmentModal = (props: CreateFragmentModalProps) => {
 			onRequestSubmit={() => {
 				if (selectedCreateOption === CreateOptions.IMPORT_JSON) {
 					// open modal with file upload
+					setFragmentSelectionCount(selectedCreateOption);
 					props.setDisplayedModal(FragmentWizardModals.IMPORT_JSON_MODAL);
 					props.setLastVisitedModal(FragmentWizardModals.CREATE_FRAGMENT_MODAL);
 					return;
 				}
 				if (selectedCreateOption === CreateOptions.EMPTY_FRAGMENT) {
+					setFragmentSelectionCount(selectedCreateOption);
 					generateFragment();
 					props.setShouldDisplay(false);
 					return;
 				}
 				if (selectedCreateOption === CreateOptions.EMPTY_PAGE) {
+					setFragmentSelectionCount(selectedCreateOption);
 					generateFragment([initializeIds(gridComponentInfo.defaultComponentObj)]);
 					props.setShouldDisplay(false);
 					return;
@@ -126,7 +135,7 @@ export const CreateFragmentModal = (props: CreateFragmentModalProps) => {
 			<p>Start with a template or create a new fragment from scratch.</p>
 			<TileGroup
 				className={createFragmentTiles}
-				defaultSelected={CreateOptions.EMPTY_PAGE}
+				defaultSelected={selectedCreateOption}
 				name="Fragment creation"
 				onChange={setSelectedCreateOption}>
 				<RadioTile

--- a/src/utils/fragment-tools.ts
+++ b/src/utils/fragment-tools.ts
@@ -5,6 +5,7 @@ import { camelCase, kebabCase, uniq, upperFirst } from 'lodash';
 import { matchPath } from 'react-router-dom';
 import { getAllFragmentStyleClasses } from '../ui-fragment/src/utils';
 import { UIFragment } from '../ui-fragment/src/ui-fragment';
+import { CreateOptions, isCreateOption } from '../routes/dashboard/fragment-wizard/create-fragment-modal';
 
 export const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -52,7 +53,7 @@ export const getFragmentPreview = async (fragment: any, props: RenderProps) => {
 	(element as HTMLElement).style.width = `${props.width || 800}px`;
 	(element as HTMLElement).style.height = `${props.height || 400}px`;
 	(element as HTMLElement).style.minHeight = `${props.height || 400}px`;
-	ReactDOM.render(React.createElement(UIFragment, { state: fragment, setState: (_state: any) => {} }), element);
+	ReactDOM.render(React.createElement(UIFragment, { state: fragment, setState: (_state: any) => { } }), element);
 	document.body.appendChild(element);
 
 	await sleep(100); // wait for render to finish
@@ -260,4 +261,24 @@ export const getFragmentJsonExport = (fragment: any, fragments: any[], styleClas
 
 export const getFragmentJsonExportString = (fragment: any, fragments: any[], styleClasses: any[]) => {
 	return JSON.stringify(getFragmentJsonExport(fragment, fragments, styleClasses), null, 2);
+};
+
+export const getMostFrequentFragmentSelection = (): CreateOptions => {
+	const fragmentSelectionCount = JSON.parse(localStorage.getItem('fragmentSelectionCount') as string || '{}');
+
+	const keys = Object.keys(fragmentSelectionCount);
+
+	if (keys.length === 0) {
+		return CreateOptions.IMPORT_JSON;
+	}
+
+	let mostfrequentselection = keys[0];
+
+	for (const key of keys) {
+		if ((fragmentSelectionCount[key] > fragmentSelectionCount[mostfrequentselection])) {
+			mostfrequentselection = key;
+		}
+	}
+
+	return isCreateOption(mostfrequentselection) ? parseInt(CreateOptions[mostfrequentselection]) : CreateOptions.IMPORT_JSON;
 };


### PR DESCRIPTION
Signed-off-by: Balaji Yaswanth Vankala <balajiyaswanth.v@gmail.com>

## Related Tickets & Documents

<!--

For Work In Progress Pull Requests, please use the [Draft pull request feature](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

For pull requests that relate or close an issue, please include them below. [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

-->

- Related Issue #203 
- Closes #


## What type of PR is this? (check all that apply)

<!--

Syntax example:
 - [x] Feature

 -->


- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update


## Scope

<!--

Describe the `what` and `why` of the PR.

ex. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

-->
This PR enhances the user experience by remembering the fragment tile selection and auto-selecting the most used fragment type by default.

## Implementation

<!--

Describe the `how` of the PR.

Provide a summary of:
 - context behind changes made
 - what reviewers should pay extra attention to
 - what, if anything, was refactored
 - who, if anyone, collaborated on this PR

-->
After a fragment is submitted then the frequency will be stored in the localstorage inside an object `fragmentSelectionCount` via global state context. The state of the `defaultSelected` fragment radio tile will be fetched from the localstorage every time. Out of all, the one with max count will be assigned to the `defaultSelected`. 

**For this feature the auto-selected value will be one of the following:-**
1. IMPORT_JSON
2. EMPTY_PAGE
3. EMPTY_FRAGMENT

## Screenshots/Recordings/Diagrams:

<!---

Include a relevant form of visual documentation

-->

## How to test
We can verify the fragment selection with the `fragmentSelectionCount` object in localstorage from browser console.
<!--

Instruct how reviewers can test changes

-->

## [optional] To-do before merge

<!---

Include any notes about things that need to happen before this PR is merged

-->

## [optional] To-do after merge

<!---

Include any notes about things that need to happen after this PR is merged

-->
