### PR TITLE
Edit mode for fragment title aligned properly

### DIFF
--- a/src/routes/edit/edit-header.tsx
+++ b/src/routes/edit/edit-header.tsx
@@ -38,7 +38,9 @@ const editHeader = css`
 			flex-flow: column;
 		}
 		.title-subheading {
-			display: inline-flex;
+			display: flex;
+			align-items: center;
+            
 			.cds--inline-loading {
 				width: auto;
 				position: relative;
@@ -59,11 +61,20 @@ const editHeader = css`
 			line-height: 2rem;
 
 			float: left;
+			display: flex;
+    		align-items: center; 
+			transition: max-height 0.3s ease; 
 		}
+		.fragment-title input {
+			max-height: 30px; /* Set the initial max-height of the input */
+			transition: max-height 0.3s ease;
+		}
+		
 		.fragment-edit {
 			margin-top: 6px;
 			cursor: pointer;
 		}
+
 	}
 
 	// This is the viewport width that causes the loading and

--- a/src/routes/edit/edit-header.tsx
+++ b/src/routes/edit/edit-header.tsx
@@ -66,7 +66,7 @@ const editHeader = css`
 			transition: max-height 0.3s ease; 
 		}
 		.fragment-title input {
-			max-height: 30px; /* Set the initial max-height of the input */
+			max-height: 30px; 
 			transition: max-height 0.3s ease;
 		}
 		


### PR DESCRIPTION
## Related Tickets & Documents

<!--

For Work In Progress Pull Requests, please use the [Draft pull request feature](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

For pull requests that relate or close an issue, please include them below. [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

-->

- Related Issue #273 
- Closes #


## What type of PR is this? (check all that apply)

<!--

Syntax example:
 - [x] Feature

 -->


- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update


## Scope

<!--

Describe the `what` and `why` of the PR.

ex. This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

-->
This PR fixes the edit mode of the fragment title where the title does not move down and the also title subheading is not shifted from its original place.

## Implementation
Flex properties of title-subheading and fragment-title were changed in order to align everything properly. 
No other changes.

<!--

Describe the `how` of the PR.

Provide a summary of:
 - context behind changes made
 - what reviewers should pay extra attention to
 - what, if anything, was refactored
 - who, if anyone, collaborated on this PR

-->


## Screenshots/Recordings/Diagrams:

https://github.com/IBM/carbon-ui-builder/assets/84861665/a1c70b7a-902a-45c0-9e67-b519dafc48f9


<!---

Include a relevant form of visual documentation

-->

## How to test

Check the UI by clicking on the edit icon besides the title in new fragment.
<!--

Instruct how reviewers can test changes

-->

## [optional] To-do before merge

<!---

Include any notes about things that need to happen before this PR is merged

-->

## [optional] To-do after merge

<!---

Include any notes about things that need to happen after this PR is merged

-->
