### PR TITLE
fix: Return empty array if collections is undefined

### DIFF
--- a/src/sdk/src/tools.ts
+++ b/src/sdk/src/tools.ts
@@ -131,7 +131,7 @@ export const getUsedCollectionsAngularStylePaths = (collections: any[], componen
 
 	return collections
 		?.filter((collection: any) => usedCollectionsNames.includes(collection.name))
-		.flatMap((collection: any) => collection.angular?.stylePaths);
+		.flatMap((collection: any) => collection.angular?.stylePaths) || [];
 };
 
 export const getUsedCollectionsAngularStyleImportPaths = (collections: any[], componentObj: any) => {
@@ -139,7 +139,7 @@ export const getUsedCollectionsAngularStyleImportPaths = (collections: any[], co
 
 	return collections
 		?.filter((collection: any) => usedCollectionsNames.includes(collection.name))
-		.flatMap((collection: any) => collection.angular?.styleImportPaths);
+		.flatMap((collection: any) => collection.angular?.styleImportPaths) || [];
 };
 
 export const getUsedCollectionsValuesByProp = (collections: any[], componentObj: any, propName: string) => {


### PR DESCRIPTION
* Fixes export modal where we attempt to spread an undefined variable.
  * Returning empty array when collections is undefined